### PR TITLE
chore: Remove unused import in operations.py

### DIFF
--- a/django_iris/operations.py
+++ b/django_iris/operations.py
@@ -1,4 +1,3 @@
-import imp
 from django.conf import settings
 from django.db import DatabaseError
 from django.db.backends.base.operations import BaseDatabaseOperations


### PR DESCRIPTION
imp import is deprecated in python 3.12 and even worth it's removed so it prevent django_iris to load in python 3.12 